### PR TITLE
Fix empty string being set on SetLicense

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.43.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2
       - name: Run golangci-lint
         run: |
           ./bin/golangci-lint run --out-format=github-actions --issues-exit-code=1

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -56,7 +56,7 @@ func GetMeteredState() {
 	fmt.Printf("Used credits: %v\n", state.Used)
 }
 
-// SetLogLevel sets the verbosity of the output produced by the UniDOC library.
+// SetLogLevel sets the verbosity of the output produced by the UniDoc library.
 func SetLogLevel(level unicommon.LogLevel) {
 	unicommon.SetLogger(unicommon.NewConsoleLogger(level))
 }

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -13,7 +13,7 @@ import (
 	unilicense "github.com/unidoc/unipdf/v3/common/license"
 )
 
-// SetLicense sets the license for using the Unidoc library.
+// SetLicense sets the license for using the UniDOC library.
 func SetLicense(licensePath string, customer string) error {
 	// Read license file
 	content, err := ioutil.ReadFile(licensePath)
@@ -21,7 +21,7 @@ func SetLicense(licensePath string, customer string) error {
 		return err
 	}
 
-	return unilicense.SetLicenseKey(string(content), "")
+	return unilicense.SetLicenseKey(string(content), customer)
 }
 
 // SetMeteredKey sets the license key for using the UniDoc library with metered api key.
@@ -56,7 +56,7 @@ func GetMeteredState() {
 	fmt.Printf("Used credits: %v\n", state.Used)
 }
 
-// SetLogLevel sets the verbosity of the output produced by the Unidoc library.
+// SetLogLevel sets the verbosity of the output produced by the UniDOC library.
 func SetLogLevel(level unicommon.LogLevel) {
 	unicommon.SetLogger(unicommon.NewConsoleLogger(level))
 }

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -13,7 +13,7 @@ import (
 	unilicense "github.com/unidoc/unipdf/v3/common/license"
 )
 
-// SetLicense sets the license for using the UniDOC library.
+// SetLicense sets the license for using the UniDoc library.
 func SetLicense(licensePath string, customer string) error {
 	// Read license file
 	content, err := ioutil.ReadFile(licensePath)


### PR DESCRIPTION
Fix for issue https://github.com/unidoc/unipdf-cli/issues/57 and update golangci-lint